### PR TITLE
Update about page styling and add navigation

### DIFF
--- a/aboutMe.html
+++ b/aboutMe.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="styles/style.css" />
 </head>
 <body>
+  <div class="nav-links">
+    <a href="index.html">Home</a> |
+    <a href="downloads/resume.pdf" download>Download Resume</a>
+  </div>
   <div class="notepad">
     <div class="notepad-content">
       <h1>Hello World!</h1>

--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="styles/style.css" />
 </head>
 <body>
+  <div class="nav-links">
+    <a href="index.html">Home</a> |
+    <a href="downloads/resume.pdf" download>Download Resume</a>
+  </div>
   <div class="container">
     <h1>Contact Me</h1>
     <form action="mailto:mmayne@ycp.edu" method="post" enctype="text/plain">

--- a/index.html
+++ b/index.html
@@ -7,8 +7,12 @@
   <title>Mark Mayne Jr</title>
   <link rel="stylesheet" href="styles/style.css" />
 </head>
-  <body>
-    <div class="terminal-window">
+<body>
+  <div class="nav-links">
+    <a href="index.html">Home</a> |
+    <a href="downloads/resume.pdf" download>Download Resume</a>
+  </div>
+  <div class="terminal-window">
       <div class="terminal-bar">
         <span class="btn close"></span>
         <span class="btn min"></span>

--- a/objectives.html
+++ b/objectives.html
@@ -7,13 +7,22 @@
   <link rel="stylesheet" href="styles/style.css">
 </head>
 <body>
+  <div class="nav-links">
+    <a href="index.html">Home</a> |
+    <a href="downloads/resume.pdf" download>Download Resume</a>
+  </div>
   <div class="chalkboard">
     <h1>Objectives</h1>
     <ul>
       <li>Build tools that inspire creativity</li>
       <li>Leverage AI for practical solutions</li>
       <li>Keep learning and share knowledge</li>
+      <li>Collaborate with fellow innovators</li>
+      <li>Release more open-source projects</li>
+      <li>Promote sustainable tech practices</li>
     </ul>
+    <p>My mission is to bridge art and technology by creating accessible tools
+    for everyone.</p>
   </div>
   <script src="scripts/main.js"></script>
 </body>

--- a/projects.html
+++ b/projects.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="styles/style.css" />
 </head>
 <body>
+  <div class="nav-links">
+    <a href="index.html">Home</a> |
+    <a href="downloads/resume.pdf" download>Download Resume</a>
+  </div>
   <div class="sticky-board">
     <div class="sticky">
       <strong><a href="https://stylesyncaiapp.com" target="_blank">StyleSync AI</a></strong>

--- a/resume.html
+++ b/resume.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="styles/style.css" />
 </head>
 <body>
+  <div class="nav-links">
+    <a href="index.html">Home</a> |
+    <a href="downloads/resume.pdf" download>Download Resume</a>
+  </div>
   <div class="container">
     <h1>Mark Mayne Jr</h1>
     <p>135 Cedar Run Dr, York, PA 17404 | (443) 996-2004 | <a href="mailto:mmayne@ycp.edu">mmayne@ycp.edu</a></p>

--- a/styles/style.css
+++ b/styles/style.css
@@ -68,8 +68,14 @@ a {
 /* Notepad (About Me) */
 .notepad {
   background-color: #fef3a3;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    #fef3a3 0px,
+    #fef3a3 29px,
+    #add8e6 30px
+  );
   border: 1px solid #ccc;
-  padding: 2rem;
+  padding: 5rem 2rem 2rem 2rem;
   margin: 3rem auto;
   width: 90%;
   max-width: 700px;
@@ -81,23 +87,27 @@ a {
 .notepad::before {
   content: '';
   position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 40px;
-  background: repeating-linear-gradient(#fef3a3, #fef3a3 38px, #eaeaea 40px);
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 5rem;
+  background-color: #fef3a3;
   z-index: 1;
 }
 .notepad::after {
   content: '';
   position: absolute;
-  top: 0; bottom: 0;
+  top: 0;
+  bottom: 0;
   left: 50px;
   width: 2px;
   background: red;
-  z-index: 0;
+  z-index: 2;
 }
 .notepad-content {
   position: relative;
-  z-index: 2;
+  z-index: 3;
+  margin-left: 60px;
 }
 
 /* Sticky Notes (Projects) */
@@ -118,6 +128,17 @@ a {
   transform: rotate(-2deg);
 }
 .sticky:nth-child(odd) { transform: rotate(2deg); }
+
+/* Simple Navigation */
+.nav-links {
+  text-align: center;
+  margin: 1rem 0;
+}
+.nav-links a {
+  margin: 0 0.5rem;
+  color: inherit;
+  font-weight: bold;
+}
 
 /* Chalkboard (Objectives) */
 .chalkboard {


### PR DESCRIPTION
## Summary
- restyle notepad background with blue lines and spacing
- add simple navigation links across all pages
- expand objectives section
- create placeholder folder for downloadable resume

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6854187228908326abddcf1ac6799ac2