### PR TITLE
Improve mobile layout

### DIFF
--- a/aboutMe.html
+++ b/aboutMe.html
@@ -20,9 +20,13 @@
     <div class="notepad-content">
       <h1>Hello World!</h1>
       <p>I'm Mark Mayne Jr., a full-stack software engineer with a passion for AI, creative tech, and making apps that solve real problems.</p>
+      <hr />
       <p>I hail from Bel Air, Maryland, and studied Computer Science at York College of PA.</p>
+      <hr />
       <p>Over the years, I've worked with defense systems, real-time simulation, and cutting-edge AI tools to build everything from military software to iOS apps.</p>
+      <hr />
       <p>These days, you’ll find me building tools like StyleSync AI and RecipeSnap AI — tech that blends utility with innovation.</p>
+      <hr />
       <p>I believe in creative expression through code, and I treat every project like an artistic medium.</p>
     </div>
   </div>

--- a/contact.html
+++ b/contact.html
@@ -16,15 +16,15 @@
   <a href="resume.html">Resume</a>
   <a href="contact.html">Contact</a>
 </div>
-  <div class="container">
+  <div class="contact-form">
     <h1>Contact Me</h1>
     <form action="mailto:mmayne@ycp.edu" method="post" enctype="text/plain">
       <label>Name:</label><br />
-      <input type="text" name="name" required /><br /><br />
+      <input type="text" name="name" required /><br />
       <label>Email:</label><br />
-      <input type="email" name="email" required /><br /><br />
+      <input type="email" name="email" required /><br />
       <label>Message:</label><br />
-      <textarea name="message" rows="5" required></textarea><br /><br />
+      <textarea name="message" rows="5" required></textarea><br />
       <input type="submit" value="Send" />
     </form>
   </div>

--- a/index.html
+++ b/index.html
@@ -8,14 +8,6 @@
   <link rel="stylesheet" href="styles/style.css" />
 </head>
 <body>
-  <div class="nav-links">
-  <a href="index.html">Home</a>
-  <a href="aboutMe.html">About</a>
-  <a href="objectives.html">Objectives</a>
-  <a href="projects.html">Projects</a>
-  <a href="resume.html">Resume</a>
-  <a href="contact.html">Contact</a>
-</div>
   <div class="terminal-window">
       <div class="terminal-bar">
         <span class="btn close"></span>

--- a/resume.html
+++ b/resume.html
@@ -7,7 +7,7 @@
   <title>Mark Mayne Jr - Resume</title>
   <link rel="stylesheet" href="styles/style.css" />
 </head>
-<body>
+<body class="resume-page">
   <div class="nav-links">
   <a href="index.html">Home</a>
   <a href="aboutMe.html">About</a>

--- a/styles/style.css
+++ b/styles/style.css
@@ -23,6 +23,7 @@ a {
   background-color: #000;
   border-radius: 6px;
   box-shadow: 0 0 10px #000;
+  box-sizing: border-box;
   width: 90%;
   max-width: 600px;
   margin: 3rem auto;
@@ -30,6 +31,7 @@ a {
 }
 .terminal-bar {
   display: flex;
+  align-items: center;
   gap: 0.4rem;
   padding: 0.4rem;
   background-color: #333;
@@ -83,6 +85,7 @@ a {
   font-family: 'Caveat', cursive;
   color: #000;
   position: relative;
+  box-sizing: border-box;
 }
 .notepad::before {
   content: '';
@@ -110,9 +113,12 @@ a {
   margin-left: 70px;
 }
 .notepad-content p {
+  margin: 0.2rem 0;
+}
+.notepad-content hr {
+  border: none;
   border-bottom: 1px solid #add8e6;
-  padding-bottom: 0.2rem;
-  margin-bottom: 0.2rem;
+  margin: 0.2rem 0;
 }
 
 /* Sticky Notes (Projects) */
@@ -122,6 +128,10 @@ a {
   justify-content: center;
   gap: 1rem;
   padding: 2rem;
+  width: 90%;
+  max-width: 700px;
+  margin: 0 auto;
+  box-sizing: border-box;
 }
 .sticky {
   background: #fffb9c;
@@ -134,11 +144,41 @@ a {
 }
 .sticky a {
   color: #0044cc;
-  background: #ffffcc;
+  background: #ffe680;
   padding: 0 4px;
   border-radius: 2px;
 }
 .sticky:nth-child(odd) { transform: rotate(2deg); }
+
+/* Contact Form */
+.contact-form {
+  background: #fff;
+  color: #000;
+  width: 90%;
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  box-sizing: border-box;
+}
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  box-sizing: border-box;
+  font-family: 'Courier New', monospace;
+}
+.contact-form input[type="submit"] {
+  background: #333;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+}
 
 /* Simple Navigation */
 .nav-links {
@@ -157,6 +197,11 @@ a {
   font-weight: bold;
 }
 
+/* Resume page link override */
+.resume-page a {
+  color: #0044cc;
+}
+
 /* Chalkboard (Objectives) */
 .chalkboard {
   background: #2b3e30;
@@ -168,6 +213,7 @@ a {
   margin: 3rem auto;
   box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
   border: 8px solid #614a3a;
+  box-sizing: border-box;
 }
 
 /* Responsive */
@@ -188,6 +234,6 @@ a {
     margin: 1rem auto;
   }
   .sticky {
-    width: 140px;
-}
+    width: 120px;
+  }
 }


### PR DESCRIPTION
## Summary
- drop nav from home page
- keep terminal toolbar aligned across devices
- add consistent lines on About Me
- adjust sticky note board and resume link colors
- style contact form and other responsive tweaks

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685426482cfc83269eec5f56a2cca7cc