### PR TITLE
Fix resume nav link color

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -197,8 +197,8 @@ a {
   font-weight: bold;
 }
 
-/* Resume page link override */
-.resume-page a {
+/* Resume page link override for content links */
+.resume-page .container a {
   color: #0044cc;
 }
 


### PR DESCRIPTION
## Summary
- keep resume page nav links white like the rest of the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854293ec5a4832681174f224489c20e