### PR TITLE
Fix about page notepad alignment

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -76,12 +76,12 @@ a {
     #fef3a3 29px,
     #add8e6 30px
   );
+  background-position: left 5rem;
   border: 1px solid #ccc;
   padding: 5rem 2rem 2rem 2rem;
   margin: 3rem auto;
   width: 90%;
   max-width: 700px;
-  line-height: 1.75;
   font-family: 'Caveat', cursive;
   color: #000;
   position: relative;
@@ -111,14 +111,17 @@ a {
   position: relative;
   z-index: 3;
   margin-left: 70px;
+  font-size: 1.1rem;
+  line-height: 30px;
 }
+.notepad-content h1,
 .notepad-content p {
-  margin: 0.2rem 0;
+  margin: 0;
 }
 .notepad-content hr {
   border: none;
   border-bottom: 1px solid #add8e6;
-  margin: 0.2rem 0;
+  margin: 0;
 }
 
 /* Sticky Notes (Projects) */
@@ -235,5 +238,9 @@ a {
   }
   .sticky {
     width: 120px;
+  }
+  .notepad-content {
+    font-size: 1rem;
+    line-height: 28px;
   }
 }


### PR DESCRIPTION
## Summary
- adjust notepad line alignment by offsetting background and setting fixed line-height
- tweak mobile styles so text aligns with notepad lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68542f764a74832695e0d53cc6d3f44c