### PR TITLE
Add social and resume links

### DIFF
--- a/aboutMe.html
+++ b/aboutMe.html
@@ -14,6 +14,9 @@
   <a href="objectives.html">Objectives</a>
   <a href="projects.html">Projects</a>
   <a href="resume.html">Resume</a>
+  <a href="downloads/resume.pdf" download>Download Resume</a>
+  <a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a>
+  <a href="https://github.com/markymark5127" target="_blank">GitHub</a>
   <a href="contact.html">Contact</a>
 </div>
   <div class="notepad">

--- a/contact.html
+++ b/contact.html
@@ -14,6 +14,9 @@
   <a href="objectives.html">Objectives</a>
   <a href="projects.html">Projects</a>
   <a href="resume.html">Resume</a>
+  <a href="downloads/resume.pdf" download>Download Resume</a>
+  <a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a>
+  <a href="https://github.com/markymark5127" target="_blank">GitHub</a>
   <a href="contact.html">Contact</a>
 </div>
   <div class="contact-form">

--- a/index.html
+++ b/index.html
@@ -19,8 +19,11 @@
         <a href="aboutMe.html">AboutMe.html</a><br />
         <a href="objectives.html">Objectives.html</a><br />
         <a href="resume.html">Resume.html</a><br />
+        <a href="downloads/resume.pdf" download>resume.pdf</a><br />
         <a href="projects.html">Projects.html</a><br />
         <a href="contact.html">Contact.html</a><br />
+        <a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a><br />
+        <a href="https://github.com/markymark5127" target="_blank">GitHub</a><br />
         <br />
         Mark's-Website:~ markmayne$ // Click a file to view it
         <span class="cursor"></span>

--- a/objectives.html
+++ b/objectives.html
@@ -13,6 +13,9 @@
   <a href="objectives.html">Objectives</a>
   <a href="projects.html">Projects</a>
   <a href="resume.html">Resume</a>
+  <a href="downloads/resume.pdf" download>Download Resume</a>
+  <a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a>
+  <a href="https://github.com/markymark5127" target="_blank">GitHub</a>
   <a href="contact.html">Contact</a>
 </div>
   <div class="chalkboard">

--- a/projects.html
+++ b/projects.html
@@ -14,6 +14,9 @@
   <a href="objectives.html">Objectives</a>
   <a href="projects.html">Projects</a>
   <a href="resume.html">Resume</a>
+  <a href="downloads/resume.pdf" download>Download Resume</a>
+  <a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a>
+  <a href="https://github.com/markymark5127" target="_blank">GitHub</a>
   <a href="contact.html">Contact</a>
 </div>
   <div class="sticky-board">

--- a/resume.html
+++ b/resume.html
@@ -14,6 +14,9 @@
   <a href="objectives.html">Objectives</a>
   <a href="projects.html">Projects</a>
   <a href="resume.html">Resume</a>
+  <a href="downloads/resume.pdf" download>Download Resume</a>
+  <a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a>
+  <a href="https://github.com/markymark5127" target="_blank">GitHub</a>
   <a href="contact.html">Contact</a>
 </div>
   <div class="container">


### PR DESCRIPTION
## Summary
- add LinkedIn/GitHub links to nav bars on all pages
- link resume download from nav bars and terminal listing

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854384fdffc8326b3a91204aea82a8e