### PR TITLE
Fix mobile terminal bar alignment

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -253,6 +253,10 @@ a {
     padding: 1rem;
     font-size: 0.95rem;
   }
+  /* Ensure the terminal bar sits flush against the top on mobile */
+  .terminal-window {
+    padding: 0;
+  }
   .notepad,
   .terminal-window,
   .chalkboard,


### PR DESCRIPTION
## Summary
- correct padding on `.terminal-window` for small screens to keep the terminal bar flush with the top

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685484af26d08326af316113ed926295