### PR TITLE
Improve resume design

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -21,38 +21,102 @@
       <li><a href="contact.html">Contact</a></li>
     </ul>
   </nav>
-  <div class="container">
-    <h1>Mark Mayne Jr</h1>
-    <p>135 Cedar Run Dr, York, PA 17404 | <a href="tel:4439962004">(443) 996-2004</a> | <a href="mailto:mmayne@ycp.edu">mmayne@ycp.edu</a></p>
-    <h2>Professional Summary</h2>
-    <p>A results-driven software engineer with experience in full-stack development, real-time systems, and defense contracting...</p>
-    <h2>Technical Skills</h2>
-    <ul>
-      <li>Languages: Python, C++, Java, JavaScript, C#, PHP, Swift</li>
-      <li>Frameworks: Angular, .NET, React, Ruby on Rails, Grails</li>
-      <li>Databases: MySQL, MongoDB, Oracle, SQLite</li>
-      <li>Tools: Docker, Jenkins, Azure DevOps, Git, Power BI</li>
-    </ul>
-    <h2>Experience</h2>
-    <p><strong>Sportsmans Deals</strong> – Software Engineer (2024–Present)</p>
-    <p>Spearheaded data analytics initiatives using MySQL, PHP, Perl, and Python for the Digiegg bitcoin project. Developed solutions for environment and pricing management optimization.</p>
-    <p><strong>Booz Allen Hamilton</strong> – Software Engineer (2019–2023)</p>
-    <p>Built UIs with Angular, TypeScript, and React for the Vantage Point project. Developed a scheduling tool using Python and PyToExcel. Designed DevSecOps CI/CD pipelines with Jenkins, SonarQube, Protractor, and Docker. Created proprietary .NET/C# software for military and satellite systems.</p>
-    <p><strong>J.F. Taylor, Inc.</strong> – Software Engineer (2018–2019)</p>
-    <p>Developed real-time aircraft simulations in openGL, C++, and QT. Integrated VR simulations using Unreal Engine and Blueprints.</p>
-    <p><strong>Computer Science Tutor</strong> - York College of Pennsylvania (2016–2018)</p>
-    <p>Mentored students in Java programming and CS principles. Supported debugging and comprehension for CS coursework.</p>
-    <p><strong>IT Help Desk Technician</strong> - York College of Pennsylvania (2014–2016)
-    <p>Resolved technical issues and maintained knowledge base content.</p>
-    <h2>Education</h2>
-    <p>York College of Pennsylvania, B.S. Computer Science, Minor in Mathematics, Graduated 2018</p>
-    <h2>Certifications & Awards</h2>
-    <ul>
-      <li>PowerPoint & Word Certified</li>
-      <li>Athletic Scholar(4-time recipient)</li>
-      <li>Kurt M. Chenowith Memorial Foundation Scholarship</li>
-      <li>Neil P. Stauffer and Ruth M. Stauffer Scholarship (2-time recipient)</li>
-    </ul>
+  <div class="resume-container">
+    <aside class="resume-sidebar">
+      <img src="assets/SuitSelfie.png" alt="Profile" class="profile-pic" />
+      <section class="about">
+        <h2>About Me</h2>
+        <p>A results-driven software engineer with experience in full-stack development, real-time systems, and defense contracting. Proven ability to deliver high-quality, scalable solutions in agile environments. Active Top Secret SCI clearance.</p>
+      </section>
+      <section class="contact">
+        <h2>Contact</h2>
+        <p>135 Cedar Run Dr, York, PA 17404</p>
+        <p><a href="tel:4439962004">(443) 996-2004</a></p>
+        <p><a href="mailto:mmayne@ycp.edu">mmayne@ycp.edu</a></p>
+      </section>
+      <section class="links">
+        <h2>Links</h2>
+        <p><a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a></p>
+        <p><a href="https://github.com/markymark5127" target="_blank">GitHub</a></p>
+      </section>
+      <section class="hobbies">
+        <h2>Hobbies</h2>
+        <ul>
+          <li>Reading</li>
+          <li>Traveling</li>
+          <li>Photography</li>
+          <li>Cooking</li>
+        </ul>
+      </section>
+    </aside>
+    <main class="resume-content">
+      <header>
+        <h1>Mark Mayne Jr</h1>
+        <h2>Software Engineer</h2>
+      </header>
+
+      <section class="experience">
+        <h2>Professional Experience</h2>
+        <div class="job">
+          <h3>Software Engineer - Sportsmans Deals</h3>
+          <p><em>Jan 2024 – Present</em></p>
+          <ul>
+            <li>Spearheaded data analytics for the Digiegg bitcoin project using MySQL, PHP, Perl, and Python.</li>
+            <li>Developed solutions for pricing management optimization.</li>
+          </ul>
+        </div>
+        <div class="job">
+          <h3>Software Engineer - Booz Allen Hamilton</h3>
+          <p><em>Jun 2019 – Dec 2023</em></p>
+          <ul>
+            <li>Built Angular, TypeScript, and React UIs for the Vantage Point project.</li>
+            <li>Developed a scheduling tool in Python and created CI/CD pipelines with Jenkins, Docker.</li>
+          </ul>
+        </div>
+        <div class="job">
+          <h3>Software Engineer - J.F. Taylor, Inc.</h3>
+          <p><em>May 2018 – Jun 2019</em></p>
+          <ul>
+            <li>Developed real-time aircraft simulations using openGL, C++, and QT.</li>
+            <li>Integrated VR with Unreal Engine and Blueprints.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="projects">
+        <h2>Projects</h2>
+        <ul>
+          <li>StyleSync AI – Outfit evaluation app using AI (Swift + OpenAI/Gemini).</li>
+          <li>RecipeSnap AI – Recipe generator from pantry images, includes OCR and AI.</li>
+        </ul>
+      </section>
+
+      <section class="education">
+        <h2>Education</h2>
+        <p><strong>York College of Pennsylvania</strong> — B.S. in Computer Science, Minor in Mathematics<br /><em>Graduated 2018</em></p>
+      </section>
+
+      <section class="skills">
+        <h2>Skills</h2>
+        <p><strong>Languages:</strong> Python, C++, Java, JavaScript, C#, PHP, Swift</p>
+        <p><strong>Frameworks:</strong> Angular, .NET, React, Ruby on Rails, Grails</p>
+        <p><strong>Databases:</strong> MySQL, MongoDB, Oracle, SQLite</p>
+        <p><strong>Tools:</strong> Docker, Jenkins, Azure DevOps, Power BI, Git</p>
+        <p><strong>Other:</strong> openDDS, RTI DDS, Unreal Engine, Agile/Scrum</p>
+      </section>
+
+      <section class="certifications">
+        <h2>Certifications & Awards</h2>
+        <ul>
+          <li>Microsoft PowerPoint and Word Certified</li>
+          <li>CPR Certified</li>
+          <li>Athletic Scholar Award (4 years)</li>
+          <li>Kurt M. Chenowith Memorial Foundation Scholarship</li>
+          <li>Neil P. Stauffer and Ruth M. Stauffer Scholarship (2-time recipient)</li>
+          <li>Life Scout, Boy Scouts of America</li>
+        </ul>
+      </section>
+    </main>
   </div>
   <script src="scripts/main.js"></script>
 </body>

--- a/styles/style.css
+++ b/styles/style.css
@@ -221,10 +221,10 @@ a {
 }
 
 /* Resume page link override for content links */
-.resume-page .container a {
+.resume-page .resume-container a {
   color: #0044cc;
 }
-.resume-page .container {
+.resume-page .resume-container {
   background: #fff;
   color: #000;
   font-family: Arial, sans-serif;
@@ -233,6 +233,90 @@ a {
   border-radius: 8px;
   padding: 2rem;
   margin-top: 2rem;
+  display: flex;
+  flex-direction: row;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.resume-page .resume-sidebar {
+  width: 35%;
+  background-color: #b25e5e;
+  color: #fff;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+.resume-page .resume-sidebar h2 {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+  border-bottom: 1px solid #555;
+  padding-bottom: 0.5rem;
+}
+.resume-page .resume-sidebar .profile-pic {
+  width: 100%;
+  border-radius: 50%;
+  margin-bottom: 1rem;
+  border: 4px solid #fff;
+}
+.resume-page .resume-sidebar ul {
+  list-style-type: square;
+  padding-left: 1.2rem;
+}
+.resume-page .resume-sidebar a {
+  color: #ccc;
+  text-decoration: none;
+}
+.resume-page .resume-sidebar a:hover {
+  text-decoration: underline;
+}
+.resume-page .resume-content {
+  width: 65%;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+.resume-page .resume-content header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+.resume-page .resume-content header h2 {
+  margin-top: 0.5rem;
+  font-weight: normal;
+  color: #777;
+}
+.resume-page .resume-content section {
+  margin-bottom: 2rem;
+}
+.resume-page .resume-content section h2 {
+  font-size: 1.3rem;
+  border-bottom: 2px solid #eee;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+.resume-page .resume-content .job h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+.resume-page .resume-content .job p {
+  margin: 0.2rem 0 0.5rem;
+  font-style: italic;
+  color: #555;
+}
+.resume-page .resume-content ul li {
+  margin-bottom: 0.5rem;
+}
+@media screen and (max-width: 768px) {
+  .resume-page .resume-container {
+    flex-direction: column;
+  }
+  .resume-page .resume-sidebar,
+  .resume-page .resume-content {
+    width: 100%;
+  }
+  .resume-page .resume-sidebar .profile-pic {
+    width: 150px;
+    margin: auto;
+    display: block;
+  }
 }
 .resume-page ul {
   margin-left: 1.2rem;


### PR DESCRIPTION
## Summary
- add resume sidebar layout with profile and info
- style sidebar with #b25e5e and responsive flex layout

## Testing
- `tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685526c8e3d88326a2b311822e9836fa