### PR TITLE
Fix mobile nav blur and z-index

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -246,10 +246,10 @@ a {
   height: 48px;
   border-radius: 50%;
   background: var(--nav-bg);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border: var(--nav-border);
-  z-index: 1100;
+  z-index: 1000;
   align-items: center;
   justify-content: center;
   cursor: pointer;
@@ -463,12 +463,12 @@ a {
     top: calc(60px + 1.5rem);
     left: 1rem;
     background: var(--nav-bg);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
     border: var(--nav-border);
     padding: 1rem;
     border-radius: 15px;
-    z-index: 1099;
+    z-index: 1000;
     width: 200px;
     box-shadow: 0 4px 10px rgba(0,0,0,0.2);
 


### PR DESCRIPTION
## Summary
- increase the blur on the mobile nav toggle and submenu for better readability
- align mobile nav z-index with the desktop navbar

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855312eba8c8326a3c7a56c86973317