### PR TITLE
Add blog section

### DIFF
--- a/aboutMe.html
+++ b/aboutMe.html
@@ -18,6 +18,7 @@
       <li><a href="objectives.html">Objectives</a></li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="resume.html">Resume</a></li>
+      <li><a href="blog.html">Blog</a></li>
       <li><a href="downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume</a></li>
       <li><a href="https://www.linkedin.com/in/mark-mayne-363547116" target="_blank">LinkedIn</a></li>
       <li><a href="https://github.com/markymark5127" target="_blank">GitHub</a></li>

--- a/blog.html
+++ b/blog.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Objectives</title>
-  <link rel="stylesheet" href="styles/style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Blog - Mark Mayne Jr</title>
+  <link rel="stylesheet" href="styles/style.css" />
 </head>
 <body>
   <nav class="navbar">
@@ -19,24 +19,18 @@
       <li><a href="resume.html">Resume</a></li>
       <li><a href="blog.html">Blog</a></li>
       <li><a href="downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume</a></li>
-      <li><a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a></li>
+      <li><a href="https://www.linkedin.com/in/mark-mayne-363547116" target="_blank">LinkedIn</a></li>
       <li><a href="https://github.com/markymark5127" target="_blank">GitHub</a></li>
       <li><a href="contact.html">Contact</a></li>
     </ul>
   </nav>
-  <div class="chalkboard">
-    <h1>Objectives</h1>
-    <ul>
-      <li>Build tools that inspire creativity</li>
-      <li>Leverage AI for practical solutions</li>
-      <li>Keep learning and share knowledge</li>
-      <li>Collaborate with fellow innovators</li>
-      <li>Release more open-source projects</li>
-      <li>Promote sustainable tech practices</li>
-    </ul>
-    <p>My mission is to bridge art and technology by creating accessible tools
-    for everyone.</p>
+  <div class="notepad">
+    <div class="notepad-content">
+      <h1>Blog Posts</h1>
+      <ul id="blog-list"></ul>
+    </div>
   </div>
   <script src="scripts/main.js"></script>
+  <script src="scripts/blog.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -18,6 +18,7 @@
       <li><a href="objectives.html">Objectives</a></li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="resume.html">Resume</a></li>
+      <li><a href="blog.html">Blog</a></li>
       <li><a href="downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume</a></li>
       <li><a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a></li>
       <li><a href="https://github.com/markymark5127" target="_blank">GitHub</a></li>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <li><a href="objectives.html">Objectives</a></li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="resume.html">Resume</a></li>
+      <li><a href="blog.html">Blog</a></li>
       <li><a href="downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume</a></li>
       <li><a href="https://www.linkedin.com/in/mark-mayne-363547116" target="_blank">LinkedIn</a></li>
       <li><a href="https://github.com/markymark5127" target="_blank">GitHub</a></li>
@@ -37,6 +38,7 @@
         <a href="resume.html">Resume.html</a><br />
         <a href="downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume.docx</a><br />
         <a href="projects.html">Projects.html</a><br />
+          <a href="blog.html">Blog.html</a><br />
         <a href="https://www.linkedin.com/in/mark-mayne-363547116" target="_blank">LinkedIn.html</a><br />
         <a href="https://github.com/markymark5127" target="_blank">GitHub.html</a><br />
         <a href="contact.html">Contact.html</a><br />

--- a/posts/first-post.html
+++ b/posts/first-post.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>My First Post</title>
+  <link rel="stylesheet" href="../styles/style.css" />
+</head>
+<body>
+  <nav class="navbar">
+    <button class="nav-toggle" aria-label="Toggle navigation">
+      <span></span><span></span><span></span>
+    </button>
+    <ul class="nav-links">
+      <li><a href="../index.html">Home</a></li>
+      <li><a href="../aboutMe.html">About</a></li>
+      <li><a href="../objectives.html">Objectives</a></li>
+      <li><a href="../projects.html">Projects</a></li>
+      <li><a href="../resume.html">Resume</a></li>
+      <li><a href="../blog.html">Blog</a></li>
+      <li><a href="../downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume</a></li>
+      <li><a href="https://www.linkedin.com/in/mark-mayne-363547116" target="_blank">LinkedIn</a></li>
+      <li><a href="https://github.com/markymark5127" target="_blank">GitHub</a></li>
+      <li><a href="../contact.html">Contact</a></li>
+    </ul>
+  </nav>
+  <div class="notepad">
+    <div class="notepad-content">
+      <h1>My First Post</h1>
+      <p>Date: April 1, 2024</p>
+      <p>This is a sample blog post to demonstrate the new blog system.</p>
+    </div>
+  </div>
+  <script src="../scripts/main.js"></script>
+</body>
+</html>

--- a/posts/posts.json
+++ b/posts/posts.json
@@ -1,0 +1,7 @@
+[
+  {
+    "title": "My First Post",
+    "date": "2024-04-01",
+    "file": "posts/first-post.html"
+  }
+]

--- a/projects.html
+++ b/projects.html
@@ -18,6 +18,7 @@
       <li><a href="objectives.html">Objectives</a></li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="resume.html">Resume</a></li>
+      <li><a href="blog.html">Blog</a></li>
       <li><a href="downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume</a></li>
       <li><a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a></li>
       <li><a href="https://github.com/markymark5127" target="_blank">GitHub</a></li>

--- a/resume.html
+++ b/resume.html
@@ -18,6 +18,7 @@
       <li><a href="objectives.html">Objectives</a></li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="resume.html">Resume</a></li>
+      <li><a href="blog.html">Blog</a></li>
       <li><a href="downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume</a></li>
       <li><a href="https://www.linkedin.com/in/mark-mayne-363547116?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app" target="_blank">LinkedIn</a></li>
       <li><a href="https://github.com/markymark5127" target="_blank">GitHub</a></li>

--- a/scripts/blog.js
+++ b/scripts/blog.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('posts/posts.json')
+    .then(res => res.json())
+    .then(posts => {
+      const list = document.getElementById('blog-list');
+      if (!list) return;
+      posts.forEach(post => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = post.file;
+        a.textContent = `${post.title} - ${post.date}`;
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+    })
+    .catch(err => {
+      console.error('Error loading posts', err);
+    });
+});


### PR DESCRIPTION
## Summary
- add blog index page and posts folder
- add sample post and JSON listing
- hook up dynamic blog list with blog.js
- link to blog from navigation on all pages
- include Blog.html link in home page terminal

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868678d7b388326af75c4d042f9175c