### PR TITLE
Enable posts from JSON

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -28,7 +28,7 @@
   <div class="notepad">
     <div class="notepad-content">
       <h1>Blog Posts</h1>
-      <ul id="blog-list"></ul>
+      <div id="blog-posts"></div>
     </div>
   </div>
   <script src="scripts/main.js"></script>

--- a/posts/posts.json
+++ b/posts/posts.json
@@ -1,12 +1,12 @@
 [
   {
     "title": "My First Post",
-    "date": "2025-06-04",
-    "file": "posts/first-post.html"
+    "date": "July 4th, 2025",
+    "content": "<p>This is my first blog post! I have a couple things in the works, developing an iPad app named PenLite, waiting for approval of my Android ports of StyleSync AI and RecipeSnap AI to be approved for the PlayStore.</p>"
   },
   {
-    "title": "Macintosh Pi update",
-    "date": "2025-06-15",
-    "file": "posts/jul-15-25.html"
+    "title": "Macintosh Pi Project",
+    "date": "July 15th, 2025",
+    "content": "<p>I have been developing a script for a Raspberry Pi 5 that automatically installs all that you need to run a Macintosh LC575 the last true 68k Compact Mac a.k.a. \"The Macintosh Mystic\". I'm developing this for my daughter so she has a computer she can play with thats not internet reliant and can play the learning 90's computer games I played when I was a kid. I designed the .stl files based around a concept Macintosh image i found in the book \"Keep It Simple The Early Design Years of Apple\" by. Hartmut Esslinger. The files are currently live on my GitHub the repo name is \"MacintoshPi_BasiliskII_System_8.1\"</p>"
   }
 ]

--- a/scripts/blog.js
+++ b/scripts/blog.js
@@ -2,15 +2,23 @@ document.addEventListener('DOMContentLoaded', () => {
   fetch('posts/posts.json')
     .then(res => res.json())
     .then(posts => {
-      const list = document.getElementById('blog-list');
-      if (!list) return;
+      const container = document.getElementById('blog-posts');
+      if (!container) return;
       posts.forEach(post => {
-        const li = document.createElement('li');
-        const a = document.createElement('a');
-        a.href = post.file;
-        a.textContent = `${post.title} - ${post.date}`;
-        li.appendChild(a);
-        list.appendChild(li);
+        const article = document.createElement('article');
+        const h2 = document.createElement('h2');
+        h2.textContent = post.title;
+
+        const dateP = document.createElement('p');
+        dateP.textContent = `Date: ${post.date}`;
+
+        const contentDiv = document.createElement('div');
+        contentDiv.innerHTML = post.content;
+
+        article.appendChild(h2);
+        article.appendChild(dateP);
+        article.appendChild(contentDiv);
+        container.appendChild(article);
       });
     })
     .catch(err => {

--- a/styles/style.css
+++ b/styles/style.css
@@ -24,14 +24,14 @@ a {
 }
 
 /* Blog posts links */
-#blog-list a {
+#blog-posts a {
   color: #ffbd2e;
 }
-.blog-page #blog-list a {
+.blog-page #blog-posts a {
   color: #3498db;
   text-decoration: underline;
 }
-.blog-page #blog-list a:hover {
+.blog-page #blog-posts a:hover {
   color: #217dbb;
 }
 


### PR DESCRIPTION
## Summary
- load blog posts from `posts.json`
- render posts directly on the blog page
- tweak CSS selectors for new blog section

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('posts/posts.json','utf8'));console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_6876b99fd3f88326ac77255a19445073