### PR TITLE
Add dynamic blog post pages

### DIFF
--- a/post.html
+++ b/post.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Post</title>
+  <link rel="stylesheet" href="styles/style.css" />
+</head>
+<body class="blog-page">
+  <nav class="navbar">
+    <button class="nav-toggle" aria-label="Toggle navigation">
+      <span></span><span></span><span></span>
+    </button>
+    <ul class="nav-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="aboutMe.html">About</a></li>
+      <li><a href="objectives.html">Objectives</a></li>
+      <li><a href="projects.html">Projects</a></li>
+      <li><a href="resume.html">Resume</a></li>
+      <li><a href="certifications.html">Certifications</a></li>
+      <li><a href="blog.html">Blog</a></li>
+      <li><a href="downloads/MarkMayne_Resume.docx" download rel="noopener noreferrer">Download Resume</a></li>
+      <li><a href="https://www.linkedin.com/in/mark-mayne-363547116" target="_blank">LinkedIn</a></li>
+      <li><a href="https://github.com/markymark5127" target="_blank">GitHub</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+  <div class="notepad">
+    <div class="notepad-content" id="post-content">
+      <h1></h1>
+      <p class="date"></p>
+      <div class="content"></div>
+    </div>
+  </div>
+  <script src="scripts/main.js"></script>
+  <script src="scripts/post.js"></script>
+</body>
+</html>

--- a/posts/posts.json
+++ b/posts/posts.json
@@ -1,11 +1,13 @@
 [
   {
     "title": "My First Post",
+    "slug": "first-post",
     "date": "July 4th, 2025",
     "content": "<p>This is my first blog post! I have a couple things in the works, developing an iPad app named PenLite, waiting for approval of my Android ports of StyleSync AI and RecipeSnap AI to be approved for the PlayStore.</p>"
   },
   {
     "title": "Macintosh Pi Project",
+    "slug": "macintosh-pi-project",
     "date": "July 15th, 2025",
     "content": "<p>I have been developing a script for a Raspberry Pi 5 that automatically installs all that you need to run a Macintosh LC575 the last true 68k Compact Mac a.k.a. \"The Macintosh Mystic\". I'm developing this for my daughter so she has a computer she can play with thats not internet reliant and can play the learning 90's computer games I played when I was a kid. I designed the .stl files based around a concept Macintosh image i found in the book \"Keep It Simple The Early Design Years of Apple\" by. Hartmut Esslinger. The files are currently live on my GitHub the repo name is \"MacintoshPi_BasiliskII_System_8.1\"</p>"
   }

--- a/scripts/blog.js
+++ b/scripts/blog.js
@@ -7,17 +7,16 @@ document.addEventListener('DOMContentLoaded', () => {
       posts.forEach(post => {
         const article = document.createElement('article');
         const h2 = document.createElement('h2');
-        h2.textContent = post.title;
+        const link = document.createElement('a');
+        link.href = `post.html?slug=${encodeURIComponent(post.slug)}`;
+        link.textContent = post.title;
+        h2.appendChild(link);
 
         const dateP = document.createElement('p');
         dateP.textContent = `Date: ${post.date}`;
 
-        const contentDiv = document.createElement('div');
-        contentDiv.innerHTML = post.content;
-
         article.appendChild(h2);
         article.appendChild(dateP);
-        article.appendChild(contentDiv);
         container.appendChild(article);
       });
     })

--- a/scripts/post.js
+++ b/scripts/post.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('slug');
+  if (!slug) return;
+
+  fetch('posts/posts.json')
+    .then(res => res.json())
+    .then(posts => {
+      const post = posts.find(p => p.slug === slug);
+      const container = document.getElementById('post-content');
+      if (!post || !container) {
+        if (container) container.textContent = 'Post not found.';
+        return;
+      }
+      document.title = post.title;
+      container.querySelector('h1').textContent = post.title;
+      container.querySelector('.date').textContent = `Date: ${post.date}`;
+      container.querySelector('.content').innerHTML = post.content;
+    })
+    .catch(err => {
+      console.error('Error loading post', err);
+    });
+});


### PR DESCRIPTION
## Summary
- extend `posts.json` with slugs
- update blog listing to link to individual post pages
- create a reusable `post.html` template
- add script to load a single post from JSON

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687792b3edf883269e442472c818653d